### PR TITLE
Add basic xUnit tests

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -56,8 +56,8 @@ jobs:
                              # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
 
     env:
-      Solution_Name: your-solution-name                         # Replace with your solution name, i.e. MyWpfApp.sln.
-      Test_Project_Path: your-test-project-path                 # Replace with the path to your test project, i.e. MyWpfApp.Tests\MyWpfApp.Tests.csproj.
+      Solution_Name: DbTableExporter.sln
+      Test_Project_Path: DbTableExporter.Tests\DbTableExporter.Tests.csproj
       Wap_Project_Directory: your-wap-project-directory-name    # Replace with the Wap project directory relative to the solution, i.e. MyWpfApp.Package.
       Wap_Project_Path: your-wap-project-path                   # Replace with the path to your Wap project, i.e. MyWpf.App.Package\MyWpfApp.Package.wapproj.
 
@@ -79,7 +79,7 @@ jobs:
 
     # Execute all unit tests in the solution
     - name: Execute unit tests
-      run: dotnet test
+      run: dotnet test $env:Test_Project_Path
 
     # Restore the application to populate the obj folder with RuntimeIdentifiers
     - name: Restore the application

--- a/DatabaseExporter.cs
+++ b/DatabaseExporter.cs
@@ -19,6 +19,11 @@ namespace DbTableExporter
             else
                 throw new ArgumentException("Unsupported dbType.");
 
+            return ExportAllTables(connection, dbType, outputFolder, log);
+        }
+
+        public static int ExportAllTables(IDbConnection connection, string dbType, string outputFolder, Action<string> log = null)
+        {
             Directory.CreateDirectory(outputFolder);
 
             using (connection)

--- a/DbTableExporter.Tests/DbTableExporter.Tests.csproj
+++ b/DbTableExporter.Tests/DbTableExporter.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DbTableExporter\DbTableExporter.csproj" />
+  </ItemGroup>
+</Project>

--- a/DbTableExporter.Tests/ExportAllTablesTests.cs
+++ b/DbTableExporter.Tests/ExportAllTablesTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+using DbTableExporter;
+
+namespace DbTableExporter.Tests
+{
+    public class FakeDbConnection : IDbConnection
+    {
+        private readonly List<DataTable> _tables;
+        private ConnectionState _state = ConnectionState.Closed;
+        public FakeDbConnection(IEnumerable<DataTable> tables)
+        {
+            _tables = tables.ToList();
+        }
+        public IEnumerable<DataTable> Tables => _tables;
+        public string ConnectionString { get; set; } = string.Empty;
+        public int ConnectionTimeout => 0;
+        public string Database => "Fake";
+        public ConnectionState State => _state;
+        public IDbTransaction BeginTransaction() => throw new NotImplementedException();
+        public void ChangeDatabase(string databaseName) { }
+        public void Close() { _state = ConnectionState.Closed; }
+        public IDbCommand CreateCommand() => new FakeDbCommand(this);
+        public void Open() { _state = ConnectionState.Open; }
+        public void Dispose() { Close(); }
+    }
+
+    public class FakeDbCommand : IDbCommand
+    {
+        private readonly FakeDbConnection _connection;
+        public FakeDbCommand(FakeDbConnection connection) { _connection = connection; }
+        public string CommandText { get; set; } = string.Empty;
+        public int CommandTimeout { get; set; }
+        public CommandType CommandType { get; set; } = CommandType.Text;
+        public IDbConnection Connection { get => _connection; set { } }
+        public IDataParameterCollection Parameters => new List<IDataParameter>();
+        public IDbTransaction Transaction { get; set; }
+        public UpdateRowSource UpdatedRowSource { get; set; }
+        public void Cancel() { }
+        public IDbDataParameter CreateParameter() => throw new NotImplementedException();
+        public void Dispose() { }
+        public int ExecuteNonQuery() => throw new NotImplementedException();
+        public IDataReader ExecuteReader() => ExecuteReader(CommandBehavior.Default);
+        public IDataReader ExecuteReader(CommandBehavior behavior)
+        {
+            if (CommandText.StartsWith("SELECT TABLE_NAME", StringComparison.OrdinalIgnoreCase))
+            {
+                var dt = new DataTable();
+                dt.Columns.Add("TABLE_NAME");
+                foreach (var t in _connection.Tables)
+                {
+                    dt.Rows.Add(t.TableName);
+                }
+                return dt.CreateDataReader();
+            }
+            else if (CommandText.StartsWith("SELECT * FROM", StringComparison.OrdinalIgnoreCase))
+            {
+                var parts = CommandText.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                var name = parts.Last().Trim('[', ']', '"');
+                var table = _connection.Tables.First(t => t.TableName == name);
+                return table.CreateDataReader();
+            }
+            throw new InvalidOperationException($"Unsupported query: {CommandText}");
+        }
+        public object ExecuteScalar() => throw new NotImplementedException();
+        public void Prepare() { }
+    }
+
+    public class ExportAllTablesTests
+    {
+        [Fact]
+        public void ExportAllTables_WritesCsv()
+        {
+            var table = new DataTable("Customers");
+            table.Columns.Add("Id", typeof(int));
+            table.Columns.Add("Name", typeof(string));
+            table.Rows.Add(1, "Alice");
+            table.Rows.Add(2, "Bob");
+
+            using var conn = new FakeDbConnection(new[] { table });
+            var output = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+            int count = DatabaseExporter.ExportAllTables(conn, "oracle", output);
+
+            Assert.Equal(1, count);
+            string file = Path.Combine(output, "Customers.csv");
+            Assert.True(File.Exists(file));
+            var lines = File.ReadAllLines(file);
+            Assert.Contains("\"Alice\"", lines[1]);
+            Assert.Contains("\"Bob\"", lines[2]);
+        }
+    }
+}

--- a/DbTableExporter.Tests/Usings.cs
+++ b/DbTableExporter.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/DbTableExporter.sln
+++ b/DbTableExporter.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31912.275
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbTableExporter", "DbTableExporter\DbTableExporter.csproj", "{488C9CB9-2B8F-4AC8-9A73-5BB5A56D15C0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbTableExporter.Tests", "DbTableExporter.Tests\DbTableExporter.Tests.csproj", "{8EE6F524-BF67-4478-97E6-2A09F240FA67}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,8 +16,12 @@ Global
 		{488C9CB9-2B8F-4AC8-9A73-5BB5A56D15C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{488C9CB9-2B8F-4AC8-9A73-5BB5A56D15C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{488C9CB9-2B8F-4AC8-9A73-5BB5A56D15C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{488C9CB9-2B8F-4AC8-9A73-5BB5A56D15C0}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {488C9CB9-2B8F-4AC8-9A73-5BB5A56D15C0}.Release|Any CPU.Build.0 = Release|Any CPU
+                {8EE6F524-BF67-4478-97E6-2A09F240FA67}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {8EE6F524-BF67-4478-97E6-2A09F240FA67}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {8EE6F524-BF67-4478-97E6-2A09F240FA67}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {8EE6F524-BF67-4478-97E6-2A09F240FA67}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/DbTableExporter/DatabaseExporter.cs
+++ b/DbTableExporter/DatabaseExporter.cs
@@ -19,6 +19,11 @@ namespace DbTableExporter
             else
                 throw new ArgumentException("Unsupported dbType.");
 
+            return ExportAllTables(connection, dbType, outputFolder, log);
+        }
+
+        public static int ExportAllTables(IDbConnection connection, string dbType, string outputFolder, Action<string> log = null)
+        {
             Directory.CreateDirectory(outputFolder);
 
             using (connection)


### PR DESCRIPTION
## Summary
- enable DI overload for `ExportAllTables`
- create xUnit test project exercising the exporter
- adjust solution file and CI workflow for tests

## Testing
- `dotnet test DbTableExporter.Tests/DbTableExporter.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876048a2c7c8323ac989f825caea7f9