### PR TITLE
Fix missing Forms namespace reference

### DIFF
--- a/DbTableExporter/DbTableExporter.csproj
+++ b/DbTableExporter/DbTableExporter.csproj
@@ -3,6 +3,8 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
+    <!-- Required for using System.Windows.Forms types such as FolderBrowserDialog -->
+    <UseWindowsForms>true</UseWindowsForms>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- reference Windows Forms in csproj so FolderBrowserDialog works

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68760feaa0108323b81589a59d18f2b1